### PR TITLE
added filebrowser

### DIFF
--- a/charts/filebrowser/Chart.yaml
+++ b/charts/filebrowser/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: filebrowser
+description: The best free self-hosted web-based file manager with source configuration, modern authentication, office support, and lightning-fast search.
+icon: https://filebrowserquantum.com/logo.svg
+type: application
+version: 0.0.1
+appVersion: 1.4.0-stable
+home: https://filebrowserquantum.com
+sources:
+  - https://github.com/gtsteffaniak/filebrowser
+annotations:
+  displayName: File Browser
+  status: alpha

--- a/charts/filebrowser/README.md
+++ b/charts/filebrowser/README.md
@@ -1,0 +1,7 @@
+### File Browser
+
+FileBrowser Quantum provides an easy way to access and manage your files from the web. It has a modern responsive interface that has many advanced features to manage users, access, sharing, and file preview and editing.
+
+#### How to Use
+
+After installing File Browser, go here to set up the app: http://files.local

--- a/charts/filebrowser/templates/configmap.yaml
+++ b/charts/filebrowser/templates/configmap.yaml
@@ -1,0 +1,18 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: filebrowser
+  namespace: {{ .Release.Name }}
+data:
+  config.yaml: |
+    frontend:
+      name: "File Browser"
+    server:
+      # using the config volume so it can persist across restarts
+      cacheDir: /etc/config/cache
+      database: /etc/config/database.db
+      sources:
+        # we'll mount all drives under here so that they're automatically indexed
+        - path: /data
+          config:
+            defaultEnabled: true

--- a/charts/filebrowser/templates/service.yaml
+++ b/charts/filebrowser/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: filebrowser
+  namespace: {{ .Release.Name }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+  selector:
+    app: filebrowser

--- a/charts/filebrowser/templates/statefulset.yaml
+++ b/charts/filebrowser/templates/statefulset.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: filebrowser
+  namespace: {{ .Release.Name }}
+  labels:
+    app: filebrowser
+spec:
+  serviceName: filebrowser
+  replicas: 1
+  selector:
+    matchLabels:
+      app: filebrowser
+  template:
+    metadata:
+      labels:
+        app: filebrowser
+        domain: apps
+    spec:
+      affinity:
+        nodeAffinity: {{ toYaml .Values.homeCloud.nodeAffinity | nindent 12 }}
+      containers:
+        - name: filebrowser
+          image: 'gtstef/filebrowser:{{ .Chart.AppVersion }}'
+          imagePullPolicy: IfNotPresent
+          # need to run as root since the mounted files are root
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 0
+          env:
+            - name: FILEBROWSER_CONFIG
+              value: /etc/config.yaml
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: configmap
+              mountPath: /etc/config/config.yaml
+              subPath: config.yaml
+            - mountPath: /etc/config
+              name: config-volume
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-data
+        - name: configmap
+          configMap:
+            name: filebrowser
+        - name: config-volume
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-config

--- a/charts/filebrowser/values.yaml
+++ b/charts/filebrowser/values.yaml
@@ -1,0 +1,11 @@
+homeCloud:
+  routes:
+    - name: files
+      service:
+        name: filebrowser
+        port: 80
+
+  # for the database
+  persistence:
+    - name: config
+      size: 1Gi


### PR DESCRIPTION
This app will serve as the universal file browser/drive for Home Cloud. Still needs some wiring in the operator to automatically provision drives so that it can see other apps data though. This is important for things like bulk uploads of files to Jellyfin.